### PR TITLE
Fix *json-cache* to avoid choking on CCL

### DIFF
--- a/lisp/src/vlime-protocol.lisp
+++ b/lisp/src/vlime-protocol.lisp
@@ -86,9 +86,11 @@
     (reverse acc)))
 
 
-(defvar *json-cache* (make-hash-table :test #'eq
-                                      :synchronized t
-                                      :weakness :key-or-value))
+(defvar *json-cache* (apply #'make-hash-table
+                            :test #'eq
+                            :weakness :key
+                            #+(or sbcl ecl) '(:synchronized t)
+                            #-(or sbcl ecl) '()))
 
 (defun form-to-json (form)
   (cond


### PR DESCRIPTION
Commit 53355895 added a `*json-cache*` hash table to cache the serialization of symbols.  To create the cache, `(make-hash-table … :weakness :key-or-value :synchronized t)` was used.  Both of those keyword arguments are non-standard (though they work in SBCL/ECL), so this commit broke Vlime in ClozureCL (and possibly other implementations that I haven't checked).

To fix Vlime in CCL, this patch does two things:

1. Uses a feature condition to only pass `:synchronized t` for SBCL and ECL.  As far as I can tell, CCL hash tables are thread-safe by default (though I wish its documentation were more explicit about this).
2. Changes the weakness to `:key`, because while CCL does have the non-standard `:weakness` option, it doesn't allow `:key-or-value`.

I *think* change 2 should be fine, because according to the SBCL manual `:key-or-value` means "either the key or the value must be live to guarantee that the entry is preserved".  But in our case, if *only* the value is live, then we couldn't possibly have a key to use in `(gethash … *json-cache*)` to look it up.  I might be wrong about this though.
