### PR TITLE
Restore Vim compat

### DIFF
--- a/vim/autoload/vlime.vim
+++ b/vim/autoload/vlime.vim
@@ -45,6 +45,7 @@ function! vlime#New(...)
                 \ 'IsConnected': function('vlime#IsConnected'),
                 \ 'Close': function('vlime#Close'),
                 \ 'Call': function('vlime#Call'),
+                \ 'SendRaw': function('vlime#SendRaw'),
                 \ 'Send': function('vlime#Send'),
                 \ 'FixRemotePath': function('vlime#FixRemotePath'),
                 \ 'FixLocalPath': function('vlime#FixLocalPath'),
@@ -200,9 +201,20 @@ endfunction
 ""
 " @dict VlimeConnection.Send
 " @usage {msg} [callback]
+" @private
+"
+" Send a raw message {msg} to the server.
+function! vlime#SendRaw(msg) dict
+    " TODO: remove that indirection?
+    return call('vlime#compat#ch_sendraw', [self.channel, a:msg])
+endfunction
+
+""
+" @dict VlimeConnection.Send
+" @usage {msg} [callback]
 " @public
 "
-" Send a raw message {msg} to the server, and optionally register an async
+" Send a message {msg} to the server, and optionally register an async
 " [callback] function to handle the reply.
 " Also an optional flag [raw] can be used to _not_ append a (swank) message ID.
 function! vlime#Send(msg, ...) dict

--- a/vim/autoload/vlime/compat.vim
+++ b/vim/autoload/vlime/compat.vim
@@ -40,7 +40,86 @@ endfunction
 function! vlime#compat#ch_open(host, port, ...)
     let Callback = get(a:000, 0, v:null)
     let timeout = get(a:000, 1, v:null)
-    return s:ch_impl.ch_open(a:host, a:port, Callback, timeout)
+    let chan_extra = {
+                \ 'next_msg_id': 10,
+                \ 'msg_callbacks': {},
+                \ 'on_data': function('vlime#compat#ch_on_data'),
+                \ }
+    if type(Callback) != type(v:null)
+        let chan_extra['chan_callback'] = Callback
+    endif
+    let ch = s:ch_impl.ch_open(a:host, a:port, chan_extra.on_data, timeout)
+    let ch['extra'] = chan_extra
+    return ch
+endfunction
+
+function! vlime#compat#ch_on_data(ch, data) dict
+    let obj_list = []
+    let bytes_want = -1
+    let buffered = get(self, 'recv_buffer', '') . a:data
+    while len(buffered) > 0
+        if bytes_want == -1
+            if len(buffered) >= 6
+                let bytes_want = str2nr(strpart(buffered, 0, 6), 16)
+                let buffered = strpart(buffered, 6)
+            else
+                " Not enough data
+                break
+            endif
+        else
+            if len(buffered) >= bytes_want
+                let input = strpart(buffered, 0, bytes_want)
+                " msgpack-special-dict - see VIM help for json_decode()
+                let input = substitute(input, "\\u0000", "", "g")
+                let json_obj = json_decode(input)
+                call add(obj_list, json_obj)
+                let buffered = strpart(buffered, bytes_want)
+                let bytes_want = -1
+            else
+                " Not enough data
+                " keep the length information for next time
+                let buffered = printf("%06x", bytes_want) . buffered
+                break
+            endif
+        endif
+    endwhile
+
+    let self['recv_buffer'] = buffered
+
+    for json_obj in obj_list
+        let type = json_obj[0]
+        let cb_index = -1
+
+        " Previously vlime always sent a callback index with a message
+        " now we've got to read swanks data directly
+        " See previous NORMALIZE-SWANK-FORM (in lisp/src/vlime-protocol.lisp)
+        if type == vlime#KW("RETURN")
+            let cb_index = remove(json_obj, -1)
+
+            if cb_index == 0
+                let CB = get(self, 'chan_callback', v:null)
+            else
+                try
+                    let CB = remove(self.msg_callbacks, cb_index)
+                catch /^Vim\%((\a\+)\)\=:E716/  " Key not present in Dictionary
+                    let CB = v:null
+                endtry
+            endif
+        else
+            let CB = get(self, 'chan_callback', v:null)
+        endif
+
+        " let json = json_encode(json_obj)
+        " echomsg 'Received [index=' . cb_index . ',json=' . strpart(json, 0, 50) . '...' strpart(json, strlen(json) - 50, 50) . ']'
+        if type(CB) != type(v:null)
+            try
+                " echomsg 'Call CB [name=' . strpart(string(CB), 0, 100) . ']'
+                call CB(self, json_obj)
+            catch /.*/
+                call vlime#ui#ErrMsg('vlime: callback failed: ' . v:exception)
+            endtry
+        endif
+    endfor
 endfunction
 
 function! vlime#compat#ch_status(chan)
@@ -66,7 +145,7 @@ function! vlime#compat#ch_sendexpr(chan, expr, ...)
 
     let msg = a:expr
     if raw_or_tag == -1
-        call add(msg, a:chan.next_msg_id)
+        call add(msg, a:chan.extra.next_msg_id)
     elseif  raw_or_tag > 0
         call add(msg, raw_or_tag)
     endif
@@ -74,22 +153,24 @@ function! vlime#compat#ch_sendexpr(chan, expr, ...)
     let json = json_encode(msg) . "\n"
     call vlime#compat#ch_sendraw(a:chan, json)
     if type(Callback) != type(v:null)
-        let a:chan.msg_callbacks[a:chan.next_msg_id] = Callback
-        "echomsg  "set idx " a:chan.next_msg_id " for " msg
-        " cb " Callback
+        let a:chan.extra.msg_callbacks[a:chan.extra.next_msg_id] = Callback
+        " echomsg  "Set CB [index=" . a:chan.extra.next_msg_id .
+        "             \ ",CB=" . strpart(string(Callback), 0, 100) .
+        "             \ "]"
     endif
-    call s:IncMsgID(a:chan)
+    call vlime#compat#inc_msg_id(a:chan)
 endfunction
 
-function! s:IncMsgID(chan)
-    if a:chan.next_msg_id >= 65535
-        let a:chan.next_msg_id = 1
+function! vlime#compat#inc_msg_id(chan)
+    if a:chan.extra.next_msg_id >= 65535
+        let a:chan.extra.next_msg_id = 1
     else
-        let a:chan.next_msg_id += 1
+        let a:chan.extra.next_msg_id += 1
     endif
 endfunction
 
 function! vlime#compat#ch_sendraw(chan, msg)
+    " echomsg 'Send [msg=' . strpart(a:msg, 0, 50) '...' strpart(a:msg, strlen(a:msg) - 50, 50) . ']'
     let l_str = printf("%06x", len(a:msg))
     let msg = l_str . a:msg
     let ret = s:ch_impl.ch_sendraw(a:chan, msg)

--- a/vim/autoload/vlime/compat.vim
+++ b/vim/autoload/vlime/compat.vim
@@ -16,6 +16,7 @@ if !exists('s:ch_impl')
                     \ 'ch_close',
                     \ 'ch_evalexpr',
                     \ 'ch_sendexpr',
+                    \ 'ch_sendraw',
                 \ ])
 endif
 
@@ -63,6 +64,9 @@ function! vlime#compat#ch_sendexpr(chan, expr, ...)
     return s:ch_impl.ch_sendexpr(a:chan, a:expr, get(a:000, 0, v:null), get(a:000, 1, -1))
 endfunction
 
+function! vlime#compat#ch_sendraw(chan, msg)
+    return s:ch_impl.ch_sendraw(a:chan, a:msg)
+endfunction
 
 function! vlime#compat#job_start(cmd, opts)
     return s:job_impl.job_start(a:cmd, a:opts)

--- a/vim/autoload/vlime/compat.vim
+++ b/vim/autoload/vlime/compat.vim
@@ -65,7 +65,9 @@ function! vlime#compat#ch_sendexpr(chan, expr, ...)
 endfunction
 
 function! vlime#compat#ch_sendraw(chan, msg)
-    return s:ch_impl.ch_sendraw(a:chan, a:msg)
+    let l_str = printf("%06x", len(a:msg))
+    let msg = l_str . a:msg
+    return s:ch_impl.ch_sendraw(a:chan, msg)
 endfunction
 
 function! vlime#compat#job_start(cmd, opts)

--- a/vim/autoload/vlime/compat/neovim.vim
+++ b/vim/autoload/vlime/compat/neovim.vim
@@ -7,13 +7,9 @@ function! vlime#compat#neovim#ch_open(host, port, callback, timeout)
     let chan_obj = {
                 \ 'hostname': a:host,
                 \ 'port': a:port,
-                \ 'on_data': function('s:ChanInputCB'),
-                \ 'next_msg_id': 10,
-                \ 'msg_callbacks': {},
+                \ 'on_data': function('vlime#compat#neovim#ch_on_data'),
+                \ 'callback': a:callback,
                 \ }
-    if type(a:callback) != type(v:null)
-        let chan_obj['chan_callback'] = a:callback
-    endif
 
     try
         let ch_id = sockconnect('tcp', a:host . ':' . a:port, chan_obj)
@@ -29,6 +25,11 @@ function! vlime#compat#neovim#ch_open(host, port, callback, timeout)
     execute 'sleep' waittime 'm'
 
     return chan_obj
+endfunction
+
+function! vlime#compat#neovim#ch_on_data(job_id, data, source) dict
+    let CB = get(self, 'callback')
+    call CB(self, join(a:data, ""))
 endfunction
 
 function! vlime#compat#neovim#ch_status(chan)
@@ -121,73 +122,6 @@ endfunction
 
 function! vlime#compat#neovim#job_getbufnr(job)
     return get(a:job, 'out_buf', 0)
-endfunction
-
-
-function! s:ChanInputCB(job_id, data, source) dict
-    let obj_list = []
-    let bytes_want = -1
-    let buffered = get(self, 'recv_buffer', '') . join(a:data, "")
-    while len(buffered) > 0
-        if bytes_want == -1 
-            if len(buffered) >= 6
-                let bytes_want = str2nr(strpart(buffered, 0, 6), 16)
-                let buffered = strpart(buffered, 6)
-            else
-                " Not enough data
-                break
-            endif
-        else
-            if len(buffered) >= bytes_want
-                let input = strpart(buffered, 0, bytes_want)
-                " msgpack-special-dict - see VIM help for json_decode()
-                let input = substitute(input, "\\u0000", "", "g")
-                let json_obj = json_decode(input)
-                call add(obj_list, json_obj)
-                let buffered = strpart(buffered, bytes_want)
-                let bytes_want = -1
-            else
-                " Not enough data
-                " keep the length information for next time
-                let buffered = printf("%06x", bytes_want) . buffered
-                break
-            endif
-        endif
-    endwhile
-
-    let self['recv_buffer'] = buffered
-
-    for json_obj in obj_list
-        let type = json_obj[0]
-
-        " Previously vlime always sent a callback index with a message
-        " now we've got to read swanks data directly
-        " See previous NORMALIZE-SWANK-FORM (in lisp/src/vlime-protocol.lisp)
-        if type == vlime#KW("RETURN")
-            let cb_index = remove(json_obj, -1)
-
-            if cb_index == 0
-                let CB = get(self, 'chan_callback', v:null)
-            else
-                try
-                    let CB = remove(self.msg_callbacks, cb_index)
-                catch /^Vim\%((\a\+)\)\=:E716/  " Key not present in Dictionary
-                    let CB = v:null
-                endtry
-            endif
-        else
-            let CB = get(self, 'chan_callback', v:null)
-        endif
-
-        "echomsg "got obj " json_encode(json_obj)
-        if type(CB) != type(v:null)
-            try
-                call CB(self, json_obj)
-            catch /.*/
-                call vlime#ui#ErrMsg('vlime: callback failed: ' . v:exception)
-            endtry
-        endif
-    endfor
 endfunction
 
 function! s:JobOutputCB(user_cb, job_id, data, source) dict

--- a/vim/autoload/vlime/compat/neovim.vim
+++ b/vim/autoload/vlime/compat/neovim.vim
@@ -80,6 +80,9 @@ function! vlime#compat#neovim#ch_sendexpr(chan, expr, callback, raw_or_tag)
     endif
 endfunction
 
+function! vlime#compat#neovim#ch_sendraw(chan, msg)
+    return chansend(a:chan.ch_id, a:msg)
+endfunction
 
 function! vlime#compat#neovim#job_start(cmd, opts)
     let buf_name = a:opts['buf_name']

--- a/vim/autoload/vlime/compat/vim.vim
+++ b/vim/autoload/vlime/compat/vim.vim
@@ -45,6 +45,9 @@ function! vlime#compat#vim#ch_sendexpr(chan, expr, callback, raw)
     endif
 endfunction
 
+function! vlime#compat#vim#ch_sendraw(chan, msg)
+    return ch_sendraw(a:chan, a:msg)
+endfunction
 
 function! vlime#compat#vim#job_start(cmd, opts)
     let buf_name = a:opts['buf_name']

--- a/vim/autoload/vlime/compat/vim.vim
+++ b/vim/autoload/vlime/compat/vim.vim
@@ -45,32 +45,9 @@ function! vlime#compat#vim#ch_evalexpr(chan, expr)
     return ch_evalexpr(a:chan.ch, a:expr)
 endfunction
 
-" XXX 99% copy pasta from vlime#compat#neovmim
-" vlime#compat#vim#ch_sendexpr(chan, expr, callback, r_or_tagaw)
-function! vlime#compat#vim#ch_sendexpr(chan, expr, callback, raw_or_tag)
-    let msg = a:expr
-    if a:raw_or_tag == -1
-        call add(msg, a:chan.next_msg_id)
-    elseif  a:raw_or_tag > 0
-        call add(msg, a:raw_or_tag)
-    endif
-
-    let json = json_encode(msg) . "\n"
-    let l_str = printf("%06x", len(json))
-    let json2 = l_str . json
-    let ret = ch_sendraw(a:chan.ch, json2)
-    echom 'ret ' . ret
-    " XXX do something with `ret`
-    if type(a:callback) != type(v:null)
-        let a:chan.msg_callbacks[a:chan.next_msg_id] = a:callback
-        "echomsg  "set idx " a:chan.next_msg_id " for " msg
-        " cb " a:callback
-    endif
-    call s:IncMsgID(a:chan)
-endfunction
-
 function! vlime#compat#vim#ch_sendraw(chan, msg)
-    return ch_sendraw(a:chan.ch, a:msg)
+    call ch_sendraw(a:chan.ch, a:msg)
+    return 1 "XXX better error management?!
 endfunction
 
 function! vlime#compat#vim#job_start(cmd, opts)
@@ -185,15 +162,6 @@ function! s:ChanInputCB(ch, data) dict
             endtry
         endif
     endfor
-endfunction
-
-" XXX 100% copy pasta from vlime#compat#neovmim
-function! s:IncMsgID(chan)
-    if a:chan.next_msg_id >= 65535
-        let a:chan.next_msg_id = 1
-    else
-        let a:chan.next_msg_id += 1
-    endif
 endfunction
 
 function! s:JobOutputCB(user_cb, chan, data)

--- a/vim/autoload/vlime/compat/vim.vim
+++ b/vim/autoload/vlime/compat/vim.vim
@@ -3,50 +3,74 @@ function! vlime#compat#vim#ch_type()
 endfunction
 
 function! vlime#compat#vim#ch_open(host, port, callback, timeout)
-    let opts = {'mode': 'json'}
+    let chan_obj = {
+                \ 'on_data': function('s:ChanInputCB'),
+                \ 'next_msg_id': 10,
+                \ 'msg_callbacks': {},
+                \ }
     if type(a:callback) != type(v:null)
-        let opts['callback'] = a:callback
+        let chan_obj['chan_callback'] = a:callback
     endif
+
+    let opts = {
+                \ 'mode': 'raw',
+                \ 'callback': chan_obj.on_data,
+                \ }
     if type(a:timeout) != type(v:null)
         let opts['waittime'] = a:timeout
     endif
-    return ch_open(a:host . ':' . string(a:port), opts)
+    let chan_obj["ch"] = ch_open(a:host . ':' . string(a:port), opts)
+    return chan_obj
 endfunction
 
 function! vlime#compat#vim#ch_status(chan)
-    let stat = ch_status(a:chan)
+    let stat = ch_status(a:chan.ch)
     return (stat == 'open') ? 'open' : 'closed'
 endfunction
 
 function! vlime#compat#vim#ch_info(chan)
-    let info = ch_info(a:chan)
+    let info = ch_info(a:chan.ch)
     return {'hostname': info['hostname'], 'port': info['port']}
 endfunction
 
 function! vlime#compat#vim#ch_close(chan)
     try
-        return ch_close(a:chan)
+        return ch_close(a:chan.ch)
     catch /^Vim\%((\a\+)\)\=:E906/  " Not an open channel
         throw 'vlime#compat#vim#ch_close: not an open channel'
     endtry
 endfunction
 
 function! vlime#compat#vim#ch_evalexpr(chan, expr)
-    return ch_evalexpr(a:chan, a:expr)
+    return ch_evalexpr(a:chan.ch, a:expr)
 endfunction
 
-" vlime#compat#vim#ch_sendexpr(chan, expr, callback, raw)
-function! vlime#compat#vim#ch_sendexpr(chan, expr, callback, raw)
-    "FIXME
-    if type(a:callback) == type(v:null)
-        return ch_sendexpr(a:chan, a:expr)
-    else
-        return ch_sendexpr(a:chan, a:expr, {'callback': a:callback})
+" XXX 99% copy pasta from vlime#compat#neovmim
+" vlime#compat#vim#ch_sendexpr(chan, expr, callback, r_or_tagaw)
+function! vlime#compat#vim#ch_sendexpr(chan, expr, callback, raw_or_tag)
+    let msg = a:expr
+    if a:raw_or_tag == -1
+        call add(msg, a:chan.next_msg_id)
+    elseif  a:raw_or_tag > 0
+        call add(msg, a:raw_or_tag)
     endif
+
+    let json = json_encode(msg) . "\n"
+    let l_str = printf("%06x", len(json))
+    let json2 = l_str . json
+    let ret = ch_sendraw(a:chan.ch, json2)
+    echom 'ret ' . ret
+    " XXX do something with `ret`
+    if type(a:callback) != type(v:null)
+        let a:chan.msg_callbacks[a:chan.next_msg_id] = a:callback
+        "echomsg  "set idx " a:chan.next_msg_id " for " msg
+        " cb " a:callback
+    endif
+    call s:IncMsgID(a:chan)
 endfunction
 
 function! vlime#compat#vim#ch_sendraw(chan, msg)
-    return ch_sendraw(a:chan, a:msg)
+    return ch_sendraw(a:chan.ch, a:msg)
 endfunction
 
 function! vlime#compat#vim#job_start(cmd, opts)
@@ -94,6 +118,82 @@ endfunction
 
 function! vlime#compat#vim#job_getbufnr(job)
     return ch_getbufnr(a:job, 'out')
+endfunction
+
+" XXX 99% copy pasta from vlime#compat#neovmim
+function! s:ChanInputCB(ch, data) dict
+    let obj_list = []
+    let bytes_want = -1
+    let buffered = get(self, 'recv_buffer', '') . a:data
+    while len(buffered) > 0
+        if bytes_want == -1 
+            if len(buffered) >= 6
+                let bytes_want = str2nr(strpart(buffered, 0, 6), 16)
+                let buffered = strpart(buffered, 6)
+            else
+                " Not enough data
+                break
+            endif
+        else
+            if len(buffered) >= bytes_want
+                let input = strpart(buffered, 0, bytes_want)
+                " msgpack-special-dict - see VIM help for json_decode()
+                let input = substitute(input, "\\u0000", "", "g")
+                let json_obj = json_decode(input)
+                call add(obj_list, json_obj)
+                let buffered = strpart(buffered, bytes_want)
+                let bytes_want = -1
+            else
+                " Not enough data
+                " keep the length information for next time
+                let buffered = printf("%06x", bytes_want) . buffered
+                break
+            endif
+        endif
+    endwhile
+
+    let self['recv_buffer'] = buffered
+
+    for json_obj in obj_list
+        let type = json_obj[0]
+
+        " Previously vlime always sent a callback index with a message
+        " now we've got to read swanks data directly
+        " See previous NORMALIZE-SWANK-FORM (in lisp/src/vlime-protocol.lisp)
+        if type == vlime#KW("RETURN")
+            let cb_index = remove(json_obj, -1)
+
+            if cb_index == 0
+                let CB = get(self, 'chan_callback', v:null)
+            else
+                try
+                    let CB = remove(self.msg_callbacks, cb_index)
+                catch /^Vim\%((\a\+)\)\=:E716/  " Key not present in Dictionary
+                    let CB = v:null
+                endtry
+            endif
+        else
+            let CB = get(self, 'chan_callback', v:null)
+        endif
+
+        "echomsg "got obj " json_encode(json_obj)
+        if type(CB) != type(v:null)
+            try
+                call CB(self, json_obj)
+            catch /.*/
+                call vlime#ui#ErrMsg('vlime: callback failed: ' . v:exception)
+            endtry
+        endif
+    endfor
+endfunction
+
+" XXX 100% copy pasta from vlime#compat#neovmim
+function! s:IncMsgID(chan)
+    if a:chan.next_msg_id >= 65535
+        let a:chan.next_msg_id = 1
+    else
+        let a:chan.next_msg_id += 1
+    endif
 endfunction
 
 function! s:JobOutputCB(user_cb, chan, data)

--- a/vim/autoload/vlime/compat/vim.vim
+++ b/vim/autoload/vlime/compat/vim.vim
@@ -4,13 +4,9 @@ endfunction
 
 function! vlime#compat#vim#ch_open(host, port, callback, timeout)
     let chan_obj = {
-                \ 'on_data': function('s:ChanInputCB'),
-                \ 'next_msg_id': 10,
-                \ 'msg_callbacks': {},
+                \ 'on_data': function('vlime#compat#vim#ch_on_data'),
+                \ 'callback': a:callback,
                 \ }
-    if type(a:callback) != type(v:null)
-        let chan_obj['chan_callback'] = a:callback
-    endif
 
     let opts = {
                 \ 'mode': 'raw',
@@ -21,6 +17,11 @@ function! vlime#compat#vim#ch_open(host, port, callback, timeout)
     endif
     let chan_obj["ch"] = ch_open(a:host . ':' . string(a:port), opts)
     return chan_obj
+endfunction
+
+function! vlime#compat#vim#ch_on_data(ch, msg) dict
+    let CB = get(self, 'callback')
+    call CB(self, a:msg)
 endfunction
 
 function! vlime#compat#vim#ch_status(chan)
@@ -98,71 +99,6 @@ function! vlime#compat#vim#job_getbufnr(job)
 endfunction
 
 " XXX 99% copy pasta from vlime#compat#neovmim
-function! s:ChanInputCB(ch, data) dict
-    let obj_list = []
-    let bytes_want = -1
-    let buffered = get(self, 'recv_buffer', '') . a:data
-    while len(buffered) > 0
-        if bytes_want == -1 
-            if len(buffered) >= 6
-                let bytes_want = str2nr(strpart(buffered, 0, 6), 16)
-                let buffered = strpart(buffered, 6)
-            else
-                " Not enough data
-                break
-            endif
-        else
-            if len(buffered) >= bytes_want
-                let input = strpart(buffered, 0, bytes_want)
-                " msgpack-special-dict - see VIM help for json_decode()
-                let input = substitute(input, "\\u0000", "", "g")
-                let json_obj = json_decode(input)
-                call add(obj_list, json_obj)
-                let buffered = strpart(buffered, bytes_want)
-                let bytes_want = -1
-            else
-                " Not enough data
-                " keep the length information for next time
-                let buffered = printf("%06x", bytes_want) . buffered
-                break
-            endif
-        endif
-    endwhile
-
-    let self['recv_buffer'] = buffered
-
-    for json_obj in obj_list
-        let type = json_obj[0]
-
-        " Previously vlime always sent a callback index with a message
-        " now we've got to read swanks data directly
-        " See previous NORMALIZE-SWANK-FORM (in lisp/src/vlime-protocol.lisp)
-        if type == vlime#KW("RETURN")
-            let cb_index = remove(json_obj, -1)
-
-            if cb_index == 0
-                let CB = get(self, 'chan_callback', v:null)
-            else
-                try
-                    let CB = remove(self.msg_callbacks, cb_index)
-                catch /^Vim\%((\a\+)\)\=:E716/  " Key not present in Dictionary
-                    let CB = v:null
-                endtry
-            endif
-        else
-            let CB = get(self, 'chan_callback', v:null)
-        endif
-
-        "echomsg "got obj " json_encode(json_obj)
-        if type(CB) != type(v:null)
-            try
-                call CB(self, json_obj)
-            catch /.*/
-                call vlime#ui#ErrMsg('vlime: callback failed: ' . v:exception)
-            endtry
-        endif
-    endfor
-endfunction
 
 function! s:JobOutputCB(user_cb, chan, data)
     let ToCall = function(a:user_cb, [[a:data]])

--- a/vim/autoload/vlime/plugin.vim
+++ b/vim/autoload/vlime/plugin.vim
@@ -215,7 +215,7 @@ function! vlime#plugin#ConnectREPL(...)
 
     call s:MaybeSendSecret(conn)
 
-    call chansend(conn.channel.ch_id, "000026(:emacs-rex (vlime::use-json) :cl t 0)")
+    call conn.SendRaw("000026(:emacs-rex (vlime::use-json) :cl t 0)")
                 " \ function('vlime#switchToJson', [], conn),
 
     call vlime#ChainCallbacks(

--- a/vim/autoload/vlime/plugin.vim
+++ b/vim/autoload/vlime/plugin.vim
@@ -1654,7 +1654,9 @@ function! s:MaybeSendSecret(conn)
     if filereadable(secret_file)
         let content = readfile(secret_file, '', 1)
         let secret = len(content) > 0 ? content[0] : ''
-        call a:conn.Send([vlime#KW('VLIME-RAW-MSG'), secret])
+        let l_str = printf("%06x", len(secret))
+        let msg = l_str . secret
+        call a:conn.SendRaw(msg)
     endif
 endfunction
 

--- a/vim/autoload/vlime/plugin.vim
+++ b/vim/autoload/vlime/plugin.vim
@@ -215,7 +215,7 @@ function! vlime#plugin#ConnectREPL(...)
 
     call s:MaybeSendSecret(conn)
 
-    call conn.SendRaw("000026(:emacs-rex (vlime::use-json) :cl t 0)")
+    call conn.SendRaw("(:emacs-rex (vlime::use-json) :cl t 0)")
                 " \ function('vlime#switchToJson', [], conn),
 
     call vlime#ChainCallbacks(
@@ -1654,9 +1654,7 @@ function! s:MaybeSendSecret(conn)
     if filereadable(secret_file)
         let content = readfile(secret_file, '', 1)
         let secret = len(content) > 0 ? content[0] : ''
-        let l_str = printf("%06x", len(secret))
-        let msg = l_str . secret
-        call a:conn.SendRaw(msg)
+        call a:conn.SendRaw(secret)
     endif
 endfunction
 

--- a/vim/autoload/vlime/ui/repl.vim
+++ b/vim/autoload/vlime/ui/repl.vim
@@ -171,7 +171,7 @@ function! s:InitREPLBuf()
     let b:matchup_delim_enabled=0 
     let b:matchup_matchparen_enabled = 0
     let b:ycm_largefile = 1
-    if type(g:ycm_filetype_blacklist) == v:t_dict
+    if exists("g:ycm_filetype_blacklist")
         let g:ycm_filetype_blacklist["vlime_repl"] = 1
     endif
 endfunction


### PR DESCRIPTION
It's working again (I had to disable automatic JSON encoding, because the Vim's format was not compatible with Swank's JSON protocol).

Anyways, the first two commits are ready to be cherry picked, as is; for the last one, I am probably going to try and refactor things a bit, given that right now I pretty much copied the whole JSON encode/decode logic from Neovim compat module.